### PR TITLE
Bug/release fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,11 @@
 #                           VULTURE_USE_SYSTEM_PYTHON is truthy.
 #   VULTURE_PY_MIN_MINOR    Minimum acceptable 3.x minor (default 12). Major is
 #                           always pinned to 3.
+#   VULTURE_PY_MAX_MINOR    Maximum acceptable 3.x minor (default 13). The agent
+#                           dependency closure caps here (litellm requires
+#                           Python <3.14); a newer host Python is rejected so
+#                           the hashed lockfile stays installable. Bump when the
+#                           closure gains support for a newer minor.
 #
 # This script is shellcheck-clean and POSIX-sh (no bashisms).
 
@@ -383,38 +388,45 @@ cli_only_note() {
     [ -n "${1:-}" ] && log "agent scanning unavailable: $1"
     log "The 'vulture' CLI and the web UI are installed and work."
     log "Agent/LLM scanning needs a local agent runtime, which is not present."
-    log "Enable it by EITHER installing Python >= 3.12 and re-running the"
+    log "Enable it by EITHER installing Python 3.12 or 3.13 and re-running the"
     log "installer (or set VULTURE_USE_SYSTEM_PYTHON=1), OR using Docker (Mode A/B)."
 }
 
 # reqs_have_hashes FILE — true iff the lockfile carries at least one --hash=.
 reqs_have_hashes() { grep -q -- '--hash=' "$1" 2>/dev/null; }
 
-# py_version_ok INTERP MIN_MINOR — true iff INTERP is CPython 3.<minor> with
-# minor >= MIN_MINOR. Ask the interpreter itself (sys.version_info); never
-# parse --version text (locale / pyenv-shim risk).
+# py_version_ok INTERP MIN_MINOR MAX_MINOR — true iff INTERP is CPython 3.<minor>
+# with MIN_MINOR <= minor <= MAX_MINOR. Ask the interpreter itself
+# (sys.version_info); never parse --version text (locale / pyenv-shim risk).
+# The upper bound is REQUIRED: the agent dependency closure has a ceiling
+# (litellm pins Requires-Python <3.14), so a too-new interpreter (e.g. 3.14)
+# cannot satisfy the hashed lockfile and must be rejected, not picked.
 py_version_ok() {
-    "$1" - "$2" <<'PY' >/dev/null 2>&1
+    "$1" - "$2" "$3" <<'PY' >/dev/null 2>&1
 import sys
-need = int(sys.argv[1]); v = sys.version_info
-sys.exit(0 if (v.major == 3 and v.minor >= need) else 1)
+lo = int(sys.argv[1]); hi = int(sys.argv[2]); v = sys.version_info
+sys.exit(0 if (v.major == 3 and lo <= v.minor <= hi) else 1)
 PY
 }
 
-# detect_system_python — honor VULTURE_PYTHON, else search newest-first; gate
-# on >= VULTURE_PY_MIN_MINOR (default 12). Echo the resolved abs path or
-# return non-zero.
+# detect_system_python — honor VULTURE_PYTHON, else search newest-SUPPORTED
+# first; gate on VULTURE_PY_MIN_MINOR (default 12) <= minor <=
+# VULTURE_PY_MAX_MINOR (default 13; bump when the agent closure supports a newer
+# Python). Echo the resolved abs path or return non-zero. python3.14 is
+# deliberately NOT in the default search — it's above the closure ceiling — but
+# an unversioned `python3` that resolves to 3.14 is still rejected by the gate.
 detect_system_python() {
     _min="${VULTURE_PY_MIN_MINOR:-12}"
+    _max="${VULTURE_PY_MAX_MINOR:-13}"
     if [ -n "${VULTURE_PYTHON:-}" ]; then
         _cands="$VULTURE_PYTHON"
     else
-        _cands="python3.14 python3.13 python3.12 python3"
+        _cands="python3.13 python3.12 python3"
     fi
     for _c in $_cands; do
         _bin=$(command -v "$_c" 2>/dev/null) || continue
         [ -x "$_bin" ] || continue
-        if py_version_ok "$_bin" "$_min"; then printf '%s\n' "$_bin"; return 0; fi
+        if py_version_ok "$_bin" "$_min" "$_max"; then printf '%s\n' "$_bin"; return 0; fi
     done
     return 1
 }
@@ -503,22 +515,25 @@ _system_python_build() {
 _install_python_deps_require() {
     [ -s "$REQS" ] || err "VULTURE_USE_SYSTEM_PYTHON set but $REQS is missing/empty; this build ships no hashed lockfile (Tier B item B1)."
     _sys_py=$(detect_system_python) \
-        || err "VULTURE_USE_SYSTEM_PYTHON set but no Python >= 3.${VULTURE_PY_MIN_MINOR:-12} found (set VULTURE_PYTHON to point at one)."
+        || err "VULTURE_USE_SYSTEM_PYTHON set but no supported Python found (need 3.${VULTURE_PY_MIN_MINOR:-12}–3.${VULTURE_PY_MAX_MINOR:-13}; the agent stack does not support 3.14 yet — set VULTURE_PYTHON to a 3.12/3.13 interpreter)."
     _system_python_build "$_sys_py"
 }
 
 # _install_python_deps_auto — AUTO path (flag unset/empty). Opts in only when a
-# hashed lockfile AND a host Python >= 3.12 are both present; otherwise it is a
-# SOFT CLI-only fall-through (exit 0, never aborts the whole install). The
-# --require-hashes gate is still enforced: a hashless lockfile is refused, but
-# softly (warn + CLI-only) rather than as a hard error.
+# hashed lockfile AND a host Python in [3.MIN, 3.MAX] (default 3.12–3.13) are
+# both present; otherwise it is a SOFT CLI-only fall-through (exit 0, never
+# aborts the whole install). The --require-hashes gate is still enforced: a
+# hashless lockfile is refused, but softly (warn + CLI-only) rather than as a
+# hard error. A too-new interpreter (e.g. 3.14) is treated as "no suitable
+# Python" — the agent closure can't install on it — so AUTO degrades to
+# CLI-only instead of failing the whole install.
 _install_python_deps_auto() {
     if [ ! -s "$REQS" ]; then
         cli_only_note "no agent lockfile in this build"
         return 0
     fi
     _sys_py=$(detect_system_python) || {
-        cli_only_note "no suitable Python >= 3.${VULTURE_PY_MIN_MINOR:-12} found"
+        cli_only_note "no suitable Python found (need 3.${VULTURE_PY_MIN_MINOR:-12}–3.${VULTURE_PY_MAX_MINOR:-13}; 3.14 is not yet supported by the agent stack)"
         return 0
     }
     if ! reqs_have_hashes "$REQS"; then

--- a/scripts/smoke-install.sh
+++ b/scripts/smoke-install.sh
@@ -46,6 +46,14 @@ export VULTURE_HOME="$SMOKE_HOME_REAL"
 export VULTURE_OFFLINE_TARBALL="$OFFLINE_TARBALL"
 export VULTURE_NO_UPDATE_CHECK=true
 export VULTURE_ALLOW_UNSIGNED=true   # local builds aren't cosign-signed
+# Force CLI-only so the smoke test stays fast and deterministic: with AUTO
+# detect (the default), a runner that happens to have Python 3.12/3.13 would
+# pull the entire hash-pinned agent closure (~80 PyPI wheels) on every release
+# build × platform, making releases slow and PyPI-flaky. The smoke test verifies
+# installer MECHANICS (download/verify/extract/CLI/doctor/uninstall); the
+# system-Python agent-install path is covered by the docker e2e matrix
+# (scripts/tests/docker) on controlled interpreters.
+export VULTURE_USE_SYSTEM_PYTHON=0
 
 # Prepare offline-companion fixtures beside the COPY (never the source dir).
 SHASUM_PATH=${OFFLINE_TARBALL%.tar.gz}.SHA256SUMS

--- a/scripts/tests/docker/runner.sh
+++ b/scripts/tests/docker/runner.sh
@@ -36,7 +36,7 @@ case "$SCENARIO" in
         [ -f "$VHOME/bin/vulture" ] || fail "bin/vulture missing"
         [ -f "$VHOME/VERSION" ] || fail "VERSION missing"
         venv_built && fail "venv was built but should not be (CLI-only)"
-        grep -qi 'agent runtime not bundled' "$OUT" || fail "missing CLI-only note"
+        grep -qi 'web UI are installed' "$OUT" || fail "missing CLI-only note"
         # doctor reports python WARN (rc 2) but install succeeded
         "$VHOME/bin/vulture" doctor >/dev/null 2>&1; drc=$?
         [ "$drc" -eq 2 ] || fail "doctor expected WARN(2) for CLI-only, got $drc"

--- a/scripts/tests/test_install_sh.sh
+++ b/scripts/tests/test_install_sh.sh
@@ -136,17 +136,23 @@ case "\$_minor" in *.*) _minor=\${_minor%%.*} ;; esac
 case "\$1" in
   -)
     # Version/self-check or import self-check script arrives on STDIN.
-    # The version gate passes the required minor as the FIRST positional
-    # ('<py> - <min>').  If a numeric arg is present, gate on it; otherwise
-    # this is an import self-check (uvicorn/fastapi/...) -> just succeed.
+    # The version gate passes the required minor as the FIRST positional and an
+    # optional MAX minor as the SECOND ('<py> - <min> [<max>]').  If a numeric
+    # arg is present, gate on [min,max]; otherwise this is an import self-check
+    # (uvicorn/fastapi/...) -> just succeed.
     shift
     _need="\${1:-}"
+    _needmax="\${2:-}"
     cat >/dev/null   # consume the heredoc body
     case "\$_need" in
       ''|*[!0-9]*) exit 0 ;;   # no numeric arg -> import self-check -> OK
     esac
-    if [ "\$_major" = "3" ] && [ "\$_minor" -ge "\$_need" ]; then exit 0; fi
-    exit 1
+    [ "\$_major" = "3" ] && [ "\$_minor" -ge "\$_need" ] || exit 1
+    case "\$_needmax" in
+      ''|*[!0-9]*) ;;                              # no max bound supplied
+      *) [ "\$_minor" -le "\$_needmax" ] || exit 1 ;;
+    esac
+    exit 0
     ;;
   -c)
     # In-line code: capability probe ('import venv, ensurepip'), version
@@ -1079,6 +1085,65 @@ test_u5_accept_312_313() {
     else fail "$name" "version gate not >= (rejected an accepted minor): $detail"; fi
 }
 test_u5_accept_312_313
+
+# ---------------------------------------------------------------------------
+# U-maxgate — version-gate-rejects-3.14 (the agent closure caps at <3.14:
+# litellm Requires-Python <3.14). REQUIRE mode (opt-in) + FAKE_PYVER=3.14 ->
+# err (non-zero) mentioning the supported 3.12/3.13 range; no venv, no pip.
+# Regression for the darwin-amd64 smoke-install failure where AUTO picked the
+# runner's python3.14 and the hash-pinned litellm had no 3.14 distribution.
+# ---------------------------------------------------------------------------
+test_umax_reject_314() {
+    name="U-maxgate-version-gate-rejects-3.14"
+    if [ "$SEAM_OK" -ne 1 ]; then fail "$name" "install_python_deps unreachable: seam absent"; return; fi
+    h=$(setup_sys_home "$SANDBOX/umax-home")
+    reset_py_logs
+    out=$(run_in_install '
+        PATH="'"$PYBIN"':'"$SHIMBIN"':'"$PATH"'"
+        VULTURE_HOME="'"$h"'"
+        VULTURE_USE_SYSTEM_PYTHON=1
+        FAKE_PYVER=3.14
+        export PATH VULTURE_HOME VULTURE_USE_SYSTEM_PYTHON FAKE_PYVER
+        install_python_deps 2>&1
+    ')
+    rc=$?
+    detail=""
+    [ "$rc" -ne 0 ] || detail="$detail expected non-zero (refuse) on 3.14 got rc=0;"
+    printf '%s' "$out" | grep -q '3\.13' || detail="$detail refusal did not mention the 3.13 ceiling;"
+    [ -f "$h/runtime/python/pyvenv.cfg" ] && detail="$detail venv built despite 3.14;"
+    [ -s "$VENV_PIP_LOG" ] && detail="$detail venv-pip invoked despite 3.14;"
+    if [ -z "$detail" ]; then pass "$name"
+    else fail "$name" "max version gate absent: $detail"; fi
+}
+test_umax_reject_314
+
+# ---------------------------------------------------------------------------
+# U-auto-max — AUTO (flag unset) on a host whose only Python is 3.14 ->
+# SOFT CLI-only (rc 0, no venv, no pip, CLI-only note). AUTO must NOT abort the
+# whole install just because the sole interpreter is above the closure ceiling.
+# ---------------------------------------------------------------------------
+test_uauto_max_cli_only_on_314() {
+    name="U-auto-max-cli-only-on-3.14"
+    if [ "$SEAM_OK" -ne 1 ]; then fail "$name" "install_python_deps unreachable: seam absent"; return; fi
+    h=$(setup_sys_home "$SANDBOX/uauto-max-home")
+    reset_py_logs
+    out=$(run_in_install '
+        PATH="'"$PYBIN"':'"$SHIMBIN"':'"$PATH"'"
+        VULTURE_HOME="'"$h"'"
+        FAKE_PYVER=3.14
+        export PATH VULTURE_HOME FAKE_PYVER
+        install_python_deps 2>&1
+    ')
+    rc=$?
+    detail=""
+    [ "$rc" -eq 0 ] || detail="$detail expected rc 0 (soft CLI-only) got rc=$rc;"
+    [ -f "$h/runtime/python/pyvenv.cfg" ] && detail="$detail venv built on 3.14 under AUTO;"
+    [ -s "$VENV_PIP_LOG" ] && detail="$detail venv-pip invoked on 3.14 under AUTO;"
+    printf '%s' "$out" | grep -Eqi 'cli|docker' || detail="$detail no CLI-only note;"
+    if [ -z "$detail" ]; then pass "$name"
+    else fail "$name" "AUTO did not degrade to CLI-only on 3.14: $detail"; fi
+}
+test_uauto_max_cli_only_on_314
 
 # ---------------------------------------------------------------------------
 # U6 — explicit-interpreter-path.


### PR DESCRIPTION
## Description

Python 3.12, 3.13 build support added. Cannot build with 3.14+ due to `litellm` dependency. no build on Darwin as the default Python version is not supported by litellm




## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] New audit agent or skill
- [x] Infrastructure / CI change

## Components Affected

- [ ] Go Backend (`backend/`)
- [ ] Python Agents (`agents/`)
- [ ] Frontend (`frontend/`)
- [ ] CLI (`cli/`)
- [x] Docker / Deployment
- [ ] Documentation (`docs/`)

## Testing Checklist

- CI must work
-  Draft release must be created